### PR TITLE
bugfix

### DIFF
--- a/core-client/transports/src/transports/duplex.rs
+++ b/core-client/transports/src/transports/duplex.rs
@@ -293,7 +293,7 @@ where
 			}
 		}
 		log::debug!("handle sink");
-		let sink_empty = match self.sink.as_mut().poll_flush(cx) {
+		let sink_empty = stream_eof || match self.sink.as_mut().poll_flush(cx) {
 			Poll::Ready(Ok(())) => true,
 			Poll::Ready(Err(_)) => true,
 			Poll::Pending => false,


### PR DESCRIPTION
If the stream closes due to an error (experienced on M1 then before, it would return Poll(Ok()). Now, it can continue